### PR TITLE
CASMHMS-5820: Pull in newer setup-helm action

### DIFF
--- a/.github/workflows/charts_lint_test_scan.yaml
+++ b/.github/workflows/charts_lint_test_scan.yaml
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1.1
+        uses: azure/setup-helm@v3
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
@@ -248,7 +248,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1.1
+        uses: azure/setup-helm@v3
 
       - name: Template chart (${{ matrix.chart }})
         run: helm template release ${{ matrix.chart }} --dry-run --replace --dependency-update > ${{ matrix.chart }}/k8s-manifest.yaml

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The update PR with comment job is composed of mostly 3rd part Github Actions
 - 3rd party Github Actions:
   - [actions/checkout@v2](https://github.com/actions/checkout/tree/v2)
   - [actions/setup-python@v2](https://github.com/actions/setup-python/tree/v2)
-  - [azure/setup-helm@v1.1](https://github.com/azure/setup-helm/tree/v1.1)
+  - [azure/setup-helm@v3](https://github.com/azure/setup-helm/tree/v3)
   - [helm/kind-action@v1.2.0](https://github.com/helm/kind-action/tree/v1.2.0)
 
 ### Scan image job


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pulled in newer version of the azure/setup-helm action from v1 to v3. This is needed to resolve an issue with the chart linting workflow where it is install a really old version of helm.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5820


## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Github actions
### Test description:

My test PR was able to successfully run the chart linting workflow: https://github.com/Cray-HPE/hms-sls-charts/actions/runs/3363500271/jobs/5576732932

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

