### PR TITLE
Fixed auth error when updating helm dependencies

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -54,15 +54,6 @@ jobs:
         with:
           version: v3.10.2
 
-      - name: Login to Artifactory helm chart repo
-        shell: bash
-        env:
-          ARTIFACTORY_REPO: ${{ inputs.artifactory-repo }}
-          ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-          ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
-        run: |
-          printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add cray-algol60 "https://artifactory.algol60.net/artifactory/${ARTIFACTORY_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
-
       - name: Determine chart versions
         id: get-chart-versions
         shell: bash
@@ -161,6 +152,9 @@ jobs:
         uses: Cray-HPE/.github/actions/csm-k8s-api-checker@v0-csm-k8s-api-checker
         env:
           CONTINUE_ON_ERROR: ${{inputs.ignore-errors}}
+          ARTIFACTORY_REPO: ${{ inputs.artifactory-repo }}
+          ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+          ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
         with:
           fail-on-deprecated: true
@@ -174,6 +168,7 @@ jobs:
             CHART_DIR=$(ls -d charts/$CHART_VERSION/* | tail -1)
 
             mkdir -p chart-build
+            printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add cray-algol60 "https://artifactory.algol60.net/artifactory/${ARTIFACTORY_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
             helm dependency update $CHART_DIR
             helm template --generate-name --dry-run $CHART_DIR > chart-build/chart-template.yaml
 


### PR DESCRIPTION

## Summary and Scope

The k8s api check was failing due to auth failures from the helm dependency update command.
```
 + helm dependency update charts/v2.1/cray-hms-bss    628Getting updates for unmanaged Helm repositories...    629...Unable to get an update from the "https://artifactory.algol60.net/artifactory/csm-helm-charts" chart repository:    630 failed to fetch https://artifactory.algol60.net/artifactory/csm-helm-charts/index.yaml : 401 Unauthorized
```
This fix is to move the helm repo add to the step where the other helm commands are run.

## Issues and Related PRs

* Resolves [CASMHMS-5960](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5960)


## Testing

### Tested on:

Tested against bss-charts and sls-charts.

### Test description:


## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

