### PR TITLE
Casmhms 6042

### DIFF
--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -31,7 +31,7 @@ on:
         default: false
       additional-artifactory-repos:
         description: |
-          Additional Artifactory repositories to configuring using 'helm repo add'
+          Additional Artifactory repositories to add using 'helm repo add' for read only access. This is an JSON array of stings.
           Example value:
           [
             "csm-helm-charts"

--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -182,7 +182,7 @@ jobs:
         ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
       run: |
         for HELM_REPO in $(jq -n 'env.ADDITIONAL_ARTIFACTORY_REPOS | fromjson[]' -r); do
-          printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add "${HELM_REPO}"" "https://artifactory.algol60.net/artifactory/${HELM_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
+          printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add "${HELM_REPO}" "https://artifactory.algol60.net/artifactory/${HELM_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
         done
 
     - name: Generate build metadata

--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -17,6 +17,18 @@ on:
         type: string
         required: false
         default: csm-helm-charts
+      additional-artifactory-repos:
+        description: |
+          Additional Artifactory repositories to configuring using 'helm repo add'
+          Example value:
+          [
+            "csm-helm-charts"
+          ]
+
+        type: string
+        required: false
+        default: '[]'
+      
       artifactory-component:
         description: The component is used to sort helm charts from the same repo internally in Artifactory. 
         type: string
@@ -147,7 +159,18 @@ jobs:
         ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
         ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
       run: |
-        printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add cray-algol60 "https://artifactory.algol60.net/artifactory/${ARTIFACTORY_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
+        printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add "${ARTIFACTORY_REPO}" "https://artifactory.algol60.net/artifactory/${ARTIFACTORY_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
+
+    - name: Login to additional Artifactory helm chart repositories
+      shell: bash
+      env:
+        ADDITIONAL_ARTIFACTORY_REPOS: ${{ inputs.additional-artifactory-repos }}
+        ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+        ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+      run: |
+        for HELM_REPO in $(jq -n 'env.ADDITIONAL_ARTIFACTORY_REPOS | fromjson[]' -r); do
+          printenv ARTIFACTORY_ALGOL60_READONLY_TOKEN | helm repo add "${HELM_REPO}"" "https://artifactory.algol60.net/artifactory/${HELM_REPO}" --username "$ARTIFACTORY_ALGOL60_READONLY_USERNAME" --password-stdin
+        done
 
     - name: Generate build metadata
       uses: Cray-HPE/hms-build-metadata-action/generate-build-metadata@v1

--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -130,8 +130,11 @@ on:
           | Failed uploaded charts count | {{ .jfrogPublish.totals.failure }} |
 
     secrets:
-      ARTIFACTORY_ALGOL60_JFROG_CLI_CONFIGURATION:
-        description: JFrog CLI configuration with permissions to upload artifacts to Artifactory
+      ARTIFACTORY_ALGOL60_USERNAME:
+        description: Artifactory username used for uploading Helm charts into Artifactory
+        required: true
+      ARTIFACTORY_ALGOL60_TOKEN:
+        description: Artifactory token used for uploading Helm charts into Artifactory
         required: true
 
       ARTIFACTORY_ALGOL60_READONLY_USERNAME:
@@ -226,7 +229,9 @@ jobs:
     
     - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ENV_1: ${{ secrets.ARTIFACTORY_ALGOL60_JFROG_CLI_CONFIGURATION }}
+        JF_URL: https://artifactory.algol60.net
+        JF_USER: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+        JF_PASSWORD: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
       if: inputs.enable-publish && steps.packaged-charts.outputs.exists == 'true'
 
     - name: Verify connectivity to Artifactory

--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -231,7 +231,7 @@ jobs:
       env:
         JF_URL: https://artifactory.algol60.net
         JF_USER: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
-        JF_PASSWORD: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+        JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
       if: inputs.enable-publish && steps.packaged-charts.outputs.exists == 'true'
 
     - name: Verify connectivity to Artifactory

--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -17,6 +17,18 @@ on:
         type: string
         required: false
         default: csm-helm-charts
+      artifactory-repo-ignore-add-failure:
+        description: |
+          Ignore failures when adding the artifactory repo using "helm repo add".
+          
+          This setting is useful when trying to populate an empty helm chart repo in artifactory, as it doesn't have an 
+          index.yaml file generated when there are no charts present. This will skip the step and the workflow should be 
+          able to complete and push the first chart into the repo. 
+
+          This flag should be set to false for normal use cases.  
+        type: boolean
+        required: false
+        default: false
       additional-artifactory-repos:
         description: |
           Additional Artifactory repositories to configuring using 'helm repo add'
@@ -154,6 +166,7 @@ jobs:
 
     - name: Login to Artifactory helm chart repo
       shell: bash
+      continue-on-error: ${{ inputs.artifactory-repo-ignore-add-failure }}
       env:
         ARTIFACTORY_REPO: ${{ inputs.artifactory-repo }}
         ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -27,24 +27,27 @@ The workflow is composed to two jobs.
 2. The [Update PR with comment job](#update-pr-with-comment-job) will run if the workflow was triggered from PR event, and will create or update a comment on the PR with links to artifacts produced by the workflow run.
 
 ### Workflow inputs
-| Name                    | Data Type | Required Field | Default value     | Description
-| ----------------------- | --------- | -------------- | ----------------- | -----------
-| `runs-on`               | `string`  | Required       | `ubuntu-latest`   | The type of machine to run the job on.
-| `target-branch`         | `string`  | Optional       | `master`          | Git repository branch to check against when determining charts that have changed.
-| `artifactory-repo`      | `string`  | Optional       | `csm-helm-charts` | Repository in Artifactory to publish Helm charts to.
-| `artifactory-component` | `string`  | Required       |                   | The component is used to sort helm charts from the same repo internally in Artifactory.
-| `enable-publish`        | `boolean` | Optional       | `true`            | Control the ability for this workflow to publish artifacts to Artifactory and create Git tags.
-| `enable-pr-comment`     | `boolean` | Optional       | `true`            | Control whether the update-pr-with-artifacts job runs on PR builds. Choose from true or false.
-| `pr-comment-search`     | `string`  | Optional       | `Here are the chart(s) we built for you` | String to look for when searching for an existing comment on a PR.
-| `pr-comment-template`   | `string`  | Optional       |                   | String containing the template to generate the PR comment with. Templated with the [Go templated language](https://pkg.go.dev/html/template).
-| `job-summary-template`  | `string`  | Optional       |                   | String containing the template to generate the job summary with. Templated with the [Go templated language](https://pkg.go.dev/html/template).
+| Name                                  | Data Type | Required Field | Default value     | Description
+| ------------------------------------- | --------- | -------------- | ----------------- | -----------
+| `runs-on`                             | `string`  | Required       | `ubuntu-latest`   | The type of machine to run the job on.
+| `target-branch`                       | `string`  | Optional       | `master`          | Git repository branch to check against when determining charts that have changed.
+| `artifactory-repo`                    | `string`  | Optional       | `csm-helm-charts` | Repository in Artifactory to publish Helm charts to.
+| `artifactory-repo-ignore-add-failure` | `boolean` | Optional | `false` | Ignore failures when adding the artifactory repo using "helm repo add". This setting is useful when trying to populate an empty helm chart repo in artifactory, as it doesn't have an index.yaml file generated when there are no charts present. This will skip the step and the workflow should be able to complete and push the first chart into the repo. 
+| `additional-artifactory-repos`        | `string`  | Optional       | `[]`              | Additional Artifactory repositories to add using 'helm repo add' for read only access. This is an JSON array of strings. Example value: `["csm-helm-charts"]`
+| `artifactory-component`               | `string`  | Required       |                   | The component is used to sort helm charts from the same repo internally in Artifactory.
+| `enable-publish`                      | `boolean` | Optional       | `true`            | Control the ability for this workflow to publish artifacts to Artifactory and create Git tags.
+| `enable-pr-comment`                   | `boolean` | Optional       | `true`            | Control whether the update-pr-with-artifacts job runs on PR builds. Choose from true or false.
+| `pr-comment-search`                   | `string`  | Optional       | `Here are the chart(s) we built for you` | String to look for when searching for an existing comment on a PR.
+| `pr-comment-template`                 | `string`  | Optional       |                   | String containing the template to generate the PR comment with. Templated with the [Go templated language](https://pkg.go.dev/html/template).
+| `job-summary-template`                | `string`  | Optional       |                   | String containing the template to generate the job summary with. Templated with the [Go templated language](https://pkg.go.dev/html/template).
 
 ### Workflow secrets
-| Name                                          | Required Field | Description 
-| --------------------------------------------- | -------------- | ----------- 
-| `ARTIFACTORY_ALGOL60_JFROG_CLI_CONFIGURATION` | Required       | JFrog CLI configuration with permissions to upload artifacts to Artifactory.
-| `ARTIFACTORY_ALGOL60_READONLY_USERNAME`       | Required       | Artifactory readonly username used to download helm charts. Note these credentials are not used to upload artifacts to artifactory.
-| `ARTIFACTORY_ALGOL60_READONLY_TOKEN`          | Required       | Artifactory readonly token for the given user to download helm charts. Note these credentials are not used to upload artifacts to artifactory.
+| Name                                    | Required Field | Description 
+| --------------------------------------- | -------------- | ----------- 
+| `ARTIFACTORY_ALGOL60_USERNAME`          | Required       | Artifactory username used for uploading Helm charts into Artifactory
+| `ARTIFACTORY_ALGOL60_TOKEN`             | Required       | Artifactory token used for uploading Helm charts into Artifactory
+| `ARTIFACTORY_ALGOL60_READONLY_USERNAME` | Required       | Artifactory readonly username used to download helm charts. Note these credentials are not used to upload artifacts to artifactory.
+| `ARTIFACTORY_ALGOL60_READONLY_TOKEN`    | Required       | Artifactory readonly token for the given user to download helm charts. Note these credentials are not used to upload artifacts to artifactory.
 
 ### Build and release job
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
These will enable publishing to the spc-helm-charts repo.
1.  The input` additional-artifactory-repos` will allow for the workflow to add additional authenticated artifcatory repos with helm add. This is useful if you are publishing to the one helm chart repo, but need to download a base chart from another repo.  
2. The input `artifactory-repo-ignore-add-failure` is a toggle that can be used to initially populate an artifactory helm chart repo that contains no helm charts. When a helm chart repo is created it contains no helm charts, and doesn't contains a index.yaml file which is required for the `helm repo add` command to be successful. When set to try this can all the workflow to run and populate the repo with a helm chart.  
3. Needed to change how the `jfrog/setup-jfrog-cli` action authenticated with Artifactory. The creds in the `ARTIFACTORY_ALGOL60_JFROG_CLI_CONFIGURATION` do not have permission to write to the required helm chart repositories. By switch to `ARTIFACTORY_ALGOL60_USERNAME` and `ARTIFACTORY_ALGOL60_TOKEN` the required access can be gained.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards incompatible.

Not all consumers of this workflow specify `secrets: inherit` in their workflow file, so the use of the different secrets will cause them to fail. So this will required bumping the version of the workflow tags to `v3` from `v2`.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-6042

## Testing

_List the environments in which these changes were tested._

### Tested on:

* hms-canary charts repo

Push to csm-helm-charts: https://github.com/Cray-HPE/hms-canary-charts/actions/runs/5338177173
```
name: Build and Publish Helm charts
on: [push, pull_request, workflow_dispatch]
jobs:
  build_and_release:
    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@CASMHMS-6042
    with:
      artifactory-component: cray-hms-canary
      target-branch: main
    secrets: inherit
```

Push to spc-helm-charts: https://github.com/Cray-HPE/hms-canary-charts/actions/runs/5338850461
```
name: Build and Publish Helm charts
on: [push, pull_request, workflow_dispatch]
jobs:
  build_and_release:
    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@CASMHMS-6042
    with:
      artifactory-component: cray-hms-canary
      artifactory-repo: spc-helm-charts
      additional-artifactory-repos: |
        ["csm-helm-charts"]
      target-branch: main
    secrets: inherit
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk as v3 tag will be created.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

