### PR TITLE
Changed to ignore errors by default on k8s_api_checker

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -16,7 +16,7 @@ on:
         description: If true the workflow will be marked as green even if the checker fails.
         type: boolean
         required: false
-        default: false
+        default: true
       check-all-charts:
         description: Set to true to check all charts
         type: boolean

--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -93,10 +93,10 @@ jobs:
               # Find the all the chart versions under the charts/ directory
               # For example, with a charts directory containing v2.0, v2.1, and v10.0,
               # the VERSIONS_SORTED field will contain:
-              # 002 000 v2.0
-              # 002 001 v2.1
               # 010 000 v10.0
-              VERSIONS_SORTED=$(ls -d v* | awk --field-separator='.' '{ printf("%03d %03d %s\n", substr($1,2),  $2, $0) }' | sort)
+              # 002 001 v2.1
+              # 002 000 v2.0
+              VERSIONS_SORTED=$(ls -d v* | awk --field-separator='.' '{ printf("%03d %03d %s\n", substr($1,2),  $2, $0) }' | sort -r)
 
               # VERSION_LIST contains the versions separated by newlines. For example:
               # v2.0
@@ -129,7 +129,9 @@ jobs:
                   uniq)
 
               if [[ ! -z "$CHANGED_VERSIONS" ]]; then
-                  VERSIONS_JSON=$(echo "$CHANGED_VERSIONS" | jq -Rnc "[inputs]")
+                  VERSIONS_SORTED=$(echo "$CHANGED_VERSIONS" | awk --field-separator='.' '{ printf("%03d %03d %s\n", substr($1,2),  $2, $0) }' | sort -r)
+                  VERSIONS_LIST=$(echo "$VERSIONS_SORTED" | awk '{ print $3 }')
+                  VERSIONS_JSON=$(echo "$VERSIONS_LIST" | jq -Rnc "[inputs]")
               fi
           else
               echo "Use user supplied chart version array"


### PR DESCRIPTION
## Summary and Scope

Some chart builds fail on the main branch because some charts use APIs that are deprecated in the latest kubernetes. Usually it is the older charts that fail.

This PR changes the workflow to not produce a failure. It will still create the full report.

In general we will not be updating kubernetes very often. The k8s APIs also rarely change. Many of the k8s APIs used by HSM are controlled by other projects. If we do update k8s in the future we can also refer back to the reports.

## Issues and Related PRs

* Resolves [CASMHMS-6190](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6190)

## Testing

### Tested on:

  * smd-charts github workflows

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

