### PR TITLE
Updated python to 3.13

### DIFF
--- a/.github/workflows/charts_lint_test_scan.yaml
+++ b/.github/workflows/charts_lint_test_scan.yaml
@@ -139,7 +139,7 @@ jobs:
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.13
         if: inputs.lint-charts || inputs.test-charts
 
       - name: Set up chart-testing


### PR DESCRIPTION
## Summary and Scope

Updated python to 3.13. Python 3.7 was no longer available on Ubuntu 24.04 which is being used in the github builds.
 

## Issues and Related PRs


## Testing

Tested with a hms-discovery-charts PR.

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

